### PR TITLE
add turn link in pre div option, and set it to default true

### DIFF
--- a/content_scripts/main.js
+++ b/content_scripts/main.js
@@ -42,6 +42,13 @@ chrome.storage.sync.get(DEFAULT_OPTIONS, function(loaded) {
   if (OPTIONS.excludedHostnames.hasOwnProperty(window.location.hostname)) {
     return;
   }
+ 
+  // Update the EXCLUDED_TAGS by user option
+  if (OPTIONS.linkOnPre){
+    EXCLUDED_TAGS.PRE = false;
+  } else {
+    EXCLUDED_TAGS.PRE = true;
+  }
 
   // Allow reddit comments to be linked
   if (window.location.hostname === "www.reddit.com") {
@@ -145,7 +152,7 @@ function shouldLinkParents(node) {
 
 // Returns true if we should link the node.
 function shouldLink(node) {
-  if (EXCLUDED_TAGS.hasOwnProperty(node.tagName) || isNodeEditable(node)) {
+  if (EXCLUDED_TAGS.hasOwnProperty(node.tagName) && EXCLUDED_TAGS[node.tagName] || isNodeEditable(node)) {
     return false;
   } else {
     return true;
@@ -196,7 +203,7 @@ function nodeFilter(node) {
       }
 
       // Skip node and all descendants of any excluded tags
-      if (EXCLUDED_TAGS.hasOwnProperty(node.tagName)) {
+      if (EXCLUDED_TAGS.hasOwnProperty(node.tagName) && EXCLUDED_TAGS[node.tagName]) {
         return NodeFilter.FILTER_REJECT;
       }
 

--- a/content_scripts/main.js
+++ b/content_scripts/main.js
@@ -152,7 +152,7 @@ function shouldLinkParents(node) {
 
 // Returns true if we should link the node.
 function shouldLink(node) {
-  if (EXCLUDED_TAGS.hasOwnProperty(node.tagName) && EXCLUDED_TAGS[node.tagName] || isNodeEditable(node)) {
+  if (EXCLUDED_TAGS[node.tagName] || isNodeEditable(node)) {
     return false;
   } else {
     return true;
@@ -203,7 +203,7 @@ function nodeFilter(node) {
       }
 
       // Skip node and all descendants of any excluded tags
-      if (EXCLUDED_TAGS.hasOwnProperty(node.tagName) && EXCLUDED_TAGS[node.tagName]) {
+      if (EXCLUDED_TAGS[node.tagName]) {
         return NodeFilter.FILTER_REJECT;
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
    "name": "LinkBot",
-   "version": "1.0.6",
+   "version": "1.0.7",
    "manifest_version": 2,
    "description": "Finds links and emails in text and makes them clickable.",
    "icons": {

--- a/options/default_options.js
+++ b/options/default_options.js
@@ -3,6 +3,7 @@ var DEFAULT_OPTIONS = {
     linkOnChange: true,
     linkEmails: true,
     linkReddit: false,
+    linkOnPre: true,
     excludedHostnames: {}
 };
 

--- a/options/options.html
+++ b/options/options.html
@@ -49,6 +49,9 @@
           <div>
             <label><input id="linkReddit" type="checkbox">Convert subreddit names outside of reddit.com</label>
           </div>
+          <div>
+            <label><input id="linkOnPre" type="checkbox">Turn link in &lt;pre&gt;</label>
+          </div>
         </form>
         <div id="footer">
           <button id="reset">Reset to defaults</button>

--- a/options/options.html
+++ b/options/options.html
@@ -50,7 +50,7 @@
             <label><input id="linkReddit" type="checkbox">Convert subreddit names outside of reddit.com</label>
           </div>
           <div>
-            <label><input id="linkOnPre" type="checkbox">Turn link in &lt;pre&gt;</label>
+            <label><input id="linkOnPre" type="checkbox">Convert links inside preformatted text blocks (&lt;pre&gt; tag)</label>
           </div>
         </form>
         <div id="footer">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LinkBot",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "license": "MIT",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Problem:
We met some request to enable to turn plain text to link in \<pre\>, 
 https://github.com/PaeP3nguin/LinkBot/issues/2,  and https://github.com/PaeP3nguin/LinkBot/issues/3

Solution:
I add an option to enable that, and the default behavior is turning the plain text to link in \<pre\>.

Testing webpage:
we have several plain links in this webpage https://raw.githubusercontent.com/PaeP3nguin/LinkBot/master/README.md , we can change our option to see whether the option works